### PR TITLE
Update passport-saml to pick up fix in xml-crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 A Hapi plugin to wrap passport-saml for use as a SAML Service Provider.
 
 This is a plugin that I built out of necessity when I couldn't find what I
-needed anywhere.  I'm not a SAML expert, and while tests are on my TODO list
-for this plugin, it was built to satisfy an immediate need and I needed it _yesterday_ so
-I view this as very much an MVP (Minimum Viable Plugin).
+needed anywhere.  I'm not a SAML expert, it was built to satisfy an immediate
+need and I needed it _yesterday_ so I view this as very much an MVP (Minimum Viable Plugin).
 
-I've tested this with samltest.id, Azure Active Directory and ADFS.  ADFS requires some
-non-standard modifications to the metadata (at least, some versions of ADFS do).  Talk
+I've tested this with https://fujifish.github.io/samling/samling.html, Azure Active Directory and ADFS.
+ADFS requires some non-standard modifications to the metadata (at least, some versions of ADFS do).  Talk
 to your IDP if things aren't going as expected.
 
 RelayState is untested, as is logout.  Encrypted assertions are also untested - the
@@ -18,7 +17,7 @@ If you're interested in expanding/improving, open an issue - chances are I'd be 
 take a PR.
 
 ## Current release
-0.1.4
+0.1.5
 
 ## Install
 
@@ -26,7 +25,7 @@ take a PR.
 
 ## Configuration
 
-Uses `http://samltest.id/` as IdP - follow the instructions there to upload your metadata.
+Uses `https://fujifish.github.io/samling/samling.html` as IdP - follow the instructions there to upload your metadata.
 Read passport-saml for how to use options in the `saml` section of `samlOptions` below.
 
 Fair warning - the `passport-saml` options assume a fair bit of background knowledge and
@@ -34,7 +33,7 @@ familiarity with specialized SAML terminology.  If you don't have that, you migh
 off scrolling down to the demo app below.
 
 ```javascript
-//this would be the samltest.id signing cert, from https://samltest.id/download/
+//this would be the samltest.id signing cert, from https://fujifish.github.io/samling/samling.html
 const idpCert = `MII...A==`;
 
 const samlOptions = {
@@ -51,6 +50,8 @@ const samlOptions = {
         // IdP Public Signing Key
         cert: idpCert,
         issuer: 'your_entity_name'
+        wantAssertionsSigned: true,
+        wantAuthnResponseSigned: true
   },
   // hapi-saml-sp settings
   config: {
@@ -102,7 +103,7 @@ that a look.
 
 ## References
 * [Saml2](https://github.com/Clever/saml2)
-* [Passport-saml](https://github.com/bergie/passport-saml)
+* [Passport-saml](https://github.com/node-saml/passport-saml)
 
 ## Based on
 * [hapi-passport-saml](https://github.com/molekilla/hapi-passport-saml)

--- a/lib/HapiSaml.js
+++ b/lib/HapiSaml.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Saml = require('passport-saml/lib/node-saml/saml');
+const { SAML } = require('@node-saml/node-saml');
 
 class HapiSaml {
 
@@ -37,7 +37,14 @@ class HapiSaml {
             throw new Error('Missing options.config.assertHooks.onResponse');
         }
 
-        this.saml = new Saml.SAML(options.saml);
+        // Default values for SAML options that are recommended in v5
+        const samlOptions = {
+            ...options.saml,
+            wantAssertionsSigned: options.saml.wantAssertionsSigned !== undefined ? options.saml.wantAssertionsSigned : true,
+            wantAuthnResponseSigned: options.saml.wantAuthnResponseSigned !== undefined ? options.saml.wantAuthnResponseSigned : true
+        };
+
+        this.saml = new SAML(samlOptions);
         this.props = Object.assign({}, options.saml);
         this.props.decryptionCert = options.config.decryptionCert;
         this.props.signingCert = options.config.signingCert;

--- a/lib/index.js
+++ b/lib/index.js
@@ -117,6 +117,7 @@ const register = (function (server, options) {
                 }
 
                 if (SAMLResponse) {
+
                     const { profile } = await saml.validatePostResponseAsync({ SAMLResponse }) || {}
 
                     if (onResponse) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-saml-sp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A Hapi plugin to wrap passport-saml for use as a SAML Service Provider",
   "main": "lib/index.js",
   "engines": {
@@ -38,10 +38,10 @@
   "homepage": "https://github.com/theoryandprinciple/hapi-saml-sp",
   "dependencies": {
     "@hapi/boom": "^10.0.0",
-    "passport-saml": "^3.2.3"
+    "@node-saml/passport-saml": "^5.0.1"
   },
   "peerDependencies": {
-    "@hapi/hapi": "^20.2.2"
+    "@hapi/hapi": ">=20.2.2 <22.0.0"
   },
   "devDependencies": {
     "@hapi/eslint-plugin": "^6.0.0",


### PR DESCRIPTION
with fix for samlstorm vulnerability (see: https://workos.com/blog/samlstorm FMI).  samltest.id has gone away since last time I touched this, so I also made some updates to the documentation here and in the demo repo so that testing is still straightforward.